### PR TITLE
Fix output format

### DIFF
--- a/src/executor/Executor.cc
+++ b/src/executor/Executor.cc
@@ -134,7 +134,6 @@ void Executor::executeParent() {
                 outputBuilder_->setExitStatus(event.exitStatus);
             }
             if (event.killed) {
-                outputBuilder_->setExitStatus(128 + event.signal);
                 outputBuilder_->setKillSignal(event.signal);
             }
             break;

--- a/src/limits/MemoryLimitListener.cc
+++ b/src/limits/MemoryLimitListener.cc
@@ -46,7 +46,7 @@ MemoryLimitListener::MemoryLimitListener(uint64_t memoryLimitKb)
                             logger::debug("Memory usage after mmap ", VAR(memoryUsage), ", ", VAR(memoryPeakKb_));
 
                             if (memoryUsage > memoryLimitKb_) {
-                                outputBuilder_->setKillReason("memory limit exceeded");
+                                outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::MLE, "memory limit exceeded");
                                 logger::debug("Limit ", VAR(memoryLimitKb_), " exceeded, killing tracee");
                                 return tracer::TraceAction::KILL;
                             }
@@ -91,7 +91,7 @@ executor::ExecuteAction MemoryLimitListener::onExecuteEvent(const executor::Exec
 
     outputBuilder_->setMemoryPeak(memoryPeakKb_);
     if (memoryLimitKb_ > 0 && memoryPeakKb_ > memoryLimitKb_) {
-        outputBuilder_->setKillReason("memory limit exceeded");
+        outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::MLE, "memory limit exceeded");
         logger::debug("Limit ", VAR(memoryLimitKb_), " exceeded, killing tracee");
         return executor::ExecuteAction::KILL;
     }

--- a/src/limits/OutputLimitListener.cc
+++ b/src/limits/OutputLimitListener.cc
@@ -46,7 +46,7 @@ executor::ExecuteAction OutputLimitListener::onExecuteEvent(const executor::Exec
 
     if (outputLimitB_ > 0 && executeEvent.signal == SIGXFSZ) {
         logger::info("Tracee got SIGXFSZ, assuming output limit exceeded");
-        outputBuilder_->setKillReason("output limit exceeded");
+        outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::OLE, "output limit exceeded");
         return executor::ExecuteAction::KILL;
     }
 

--- a/src/limits/TimeLimitListener.cc
+++ b/src/limits/TimeLimitListener.cc
@@ -77,21 +77,21 @@ void TimeLimitListener::onPostExecute() {
 
 executor::ExecuteAction TimeLimitListener::verifyTimeUsage() {
     if (rTimelimitUs_ != 0 && getRealTimeUsage() > rTimelimitUs_) {
-        outputBuilder_->setKillReason("real time limit exceeded");
+        outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::TLE, "real time limit exceeded");
         return executor::ExecuteAction::KILL;
     }
     if (uTimelimitUs_ != 0 || sTimelimitUs_ != 0 || usTimelimitUs_ != 0) {
         ProcessTimeUsage ptu = getProcessTimeUsage();
         if (uTimelimitUs_ != 0 && ptu.uTimeUs > uTimelimitUs_) {
-            outputBuilder_->setKillReason("user time limit exceeded");
+            outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::TLE, "user time limit exceeded");
             return executor::ExecuteAction::KILL;
         }
         if (sTimelimitUs_ != 0 && ptu.sTimeUs > sTimelimitUs_) {
-            outputBuilder_->setKillReason("system time limit exceeded");
+            outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::TLE, "system time limit exceeded");
             return executor::ExecuteAction::KILL;
         }
         if (usTimelimitUs_ != 0 && ptu.uTimeUs + ptu.sTimeUs > usTimelimitUs_) {
-            outputBuilder_->setKillReason("user+system time limit exceeded");
+            outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::TLE, "user+system time limit exceeded");
             return executor::ExecuteAction::KILL;
         }
     }

--- a/src/perf/PerfListener.cc
+++ b/src/perf/PerfListener.cc
@@ -124,7 +124,7 @@ executor::ExecuteAction PerfListener::onSigioSignal() {
     uint64_t instructionsUsed = getInstructionsUsed();
     if (instructionCountLimit_ != 0 && instructionsUsed >= instructionCountLimit_) {
         logger::debug("Killing tracee after instructions count ", instructionsUsed, " exceeded limit");
-        outputBuilder_->setKillReason("time limit exceeded");
+        outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::TLE, "time limit exceeded");
         return executor::ExecuteAction::KILL;
     }
     return executor::ExecuteAction::CONTINUE;

--- a/src/printer/OITimeToolOutputBuilder.cc
+++ b/src/printer/OITimeToolOutputBuilder.cc
@@ -37,10 +37,13 @@ OutputBuilder& OITimeToolOutputBuilder::setKillSignal(uint32_t killSignal) {
     return *this;
 }
 
-OutputBuilder& OITimeToolOutputBuilder::setKillReason(const std::string& reason) {
+OutputBuilder& OITimeToolOutputBuilder::setKillReason(KillReason reason, const std::string& comment) {
     // Remember only first kill reason
-    if (killReason_.empty())
+    if (killReason_ == OK) {
         killReason_ = reason;
+        killReasonComment_ = comment;
+    }
+
     return *this;
 }
 
@@ -59,8 +62,8 @@ std::string OITimeToolOutputBuilder::dump() const {
 }
 
 void OITimeToolOutputBuilder::dumpStatus(std::ostream& ss) const {
-    if (!killReason_.empty()) {
-        ss << killReason_;
+    if (killReason_ != OK) {
+            ss << killReasonComment_;
     }
     else if (killSignal_ > 0) {
         ss << "process exited due to signal " << killSignal_;

--- a/src/printer/OITimeToolOutputBuilder.cc
+++ b/src/printer/OITimeToolOutputBuilder.cc
@@ -1,4 +1,5 @@
 #include "OITimeToolOutputBuilder.h"
+#include "common/Exception.h"
 
 #include <sstream>
 
@@ -75,14 +76,6 @@ void OITimeToolOutputBuilder::dumpStatus(std::ostream& ss) const {
 }
 
 int OITimeToolOutputBuilder::encodeStatusCode() const {
-    static const int CODES[] = {
-        [KillReason::NONE] = 0,
-        [KillReason::RE] = 100,
-        [KillReason::RV] = 121,
-        [KillReason::TLE] = 125,
-        [KillReason::MLE] = 124,
-        [KillReason::OLE] = 120,
-    };
     static const int CODE_SIG_BASE = 0;
     static const int CODE_RE_BASE = 200;
 
@@ -94,7 +87,16 @@ int OITimeToolOutputBuilder::encodeStatusCode() const {
             return CODE_RE_BASE + exitStatus_;
         }
     }
-    return CODES[killReason_];
+
+    switch (killReason_){
+        case KillReason::NONE: return 0;
+        case KillReason::RE:  return 100;
+        case KillReason::RV:  return 121;
+        case KillReason::TLE: return 125;
+        case KillReason::MLE: return 124;
+        case KillReason::OLE: return 120;
+    };
+    __builtin_unreachable();
 }
 
 }

--- a/src/printer/OITimeToolOutputBuilder.cc
+++ b/src/printer/OITimeToolOutputBuilder.cc
@@ -23,8 +23,6 @@ OutputBuilder& OITimeToolOutputBuilder::setMemoryPeak(uint64_t memoryPeakKb) {
 OutputBuilder& OITimeToolOutputBuilder::setExitStatus(uint32_t exitStatus) {
     if (exitStatus_ == 0) {
         exitStatus_ = exitStatus;
-        if (exitStatus > 128)
-            setKillSignal(exitStatus - 128);
     }
     return *this;
 }
@@ -67,6 +65,9 @@ void OITimeToolOutputBuilder::dumpStatus(std::ostream& ss) const {
     }
     else if (killSignal_ > 0) {
         ss << "process exited due to signal " << killSignal_;
+    }
+    else if (exitStatus_ > 0) {
+        ss << "runtime error " << exitStatus_;
     }
     else {
         ss << "ok";

--- a/src/printer/OITimeToolOutputBuilder.cc
+++ b/src/printer/OITimeToolOutputBuilder.cc
@@ -37,7 +37,7 @@ OutputBuilder& OITimeToolOutputBuilder::setKillSignal(uint32_t killSignal) {
 
 OutputBuilder& OITimeToolOutputBuilder::setKillReason(KillReason reason, const std::string& comment) {
     // Remember only first kill reason
-    if (killReason_ == OK) {
+    if (killReason_ == KillReason::NONE) {
         killReason_ = reason;
         killReasonComment_ = comment;
     }
@@ -60,7 +60,7 @@ std::string OITimeToolOutputBuilder::dump() const {
 }
 
 void OITimeToolOutputBuilder::dumpStatus(std::ostream& ss) const {
-    if (killReason_ != OK) {
+    if (killReason_ != KillReason::NONE) {
             ss << killReasonComment_;
     }
     else if (killSignal_ > 0) {
@@ -76,7 +76,7 @@ void OITimeToolOutputBuilder::dumpStatus(std::ostream& ss) const {
 
 int OITimeToolOutputBuilder::encodeStatusCode() const {
     static const int CODES[] = {
-        [KillReason::OK] = 0,
+        [KillReason::NONE] = 0,
         [KillReason::RE] = 100,
         [KillReason::RV] = 121,
         [KillReason::TLE] = 125,
@@ -86,7 +86,7 @@ int OITimeToolOutputBuilder::encodeStatusCode() const {
     static const int CODE_SIG_BASE = 0;
     static const int CODE_RE_BASE = 200;
 
-    if (killReason_ == KillReason::OK) {
+    if (killReason_ == KillReason::NONE) {
         // NOTE: order of ifs is important, as nonzero killSignal also sets exitStatus_
         if (killSignal_ > 0) {
             return CODE_SIG_BASE + killSignal_;

--- a/src/printer/OITimeToolOutputBuilder.cc
+++ b/src/printer/OITimeToolOutputBuilder.cc
@@ -48,7 +48,7 @@ OutputBuilder& OITimeToolOutputBuilder::setKillReason(KillReason reason, const s
 std::string OITimeToolOutputBuilder::dump() const {
     // mimic orginal oititmetools' output
     std::stringstream ss;
-    ss << "__RESULT__ " << exitStatus_
+    ss << "__RESULT__ " << encodeStatusCode()
         << " " << milliSecondsElapsed_
         << " " << 0ULL
         << " " << memoryPeakKb_
@@ -72,6 +72,29 @@ void OITimeToolOutputBuilder::dumpStatus(std::ostream& ss) const {
     else {
         ss << "ok";
     }
+}
+
+int OITimeToolOutputBuilder::encodeStatusCode() const {
+    static const int CODES[] = {
+        [KillReason::OK] = 0,
+        [KillReason::RE] = 100,
+        [KillReason::RV] = 121,
+        [KillReason::TLE] = 125,
+        [KillReason::MLE] = 124,
+        [KillReason::OLE] = 120,
+    };
+    static const int CODE_SIG_BASE = 0;
+    static const int CODE_RE_BASE = 200;
+
+    if (killReason_ == KillReason::OK) {
+        // NOTE: order of ifs is important, as nonzero killSignal also sets exitStatus_
+        if (killSignal_ > 0) {
+            return CODE_SIG_BASE + killSignal_;
+        } else if (exitStatus_ > 0) {
+            return CODE_RE_BASE + exitStatus_;
+        }
+    }
+    return CODES[killReason_];
 }
 
 }

--- a/src/printer/OITimeToolOutputBuilder.h
+++ b/src/printer/OITimeToolOutputBuilder.h
@@ -21,6 +21,7 @@ public:
 
 private:
     void dumpStatus(std::ostream& ss) const;
+    int encodeStatusCode() const;
 
     static const uint64_t CYCLES_PER_SECOND = 2'000'000'000;
 

--- a/src/printer/OITimeToolOutputBuilder.h
+++ b/src/printer/OITimeToolOutputBuilder.h
@@ -13,7 +13,7 @@ public:
     OutputBuilder& setMemoryPeak(uint64_t memoryPeakKb) override;
     OutputBuilder& setExitStatus(uint32_t exitStatus) override;
     OutputBuilder& setKillSignal(uint32_t killSignal) override;
-    OutputBuilder& setKillReason(const std::string& reason) override;
+    OutputBuilder& setKillReason(KillReason reason, const std::string& comment) override;
 
     std::string dump() const override;
 
@@ -31,7 +31,8 @@ private:
     uint32_t killSignal_;
 
     // TODO
-    std::string killReason_;
+    KillReason killReason_ = KillReason::OK;
+    std::string killReasonComment_;
 };
 
 }

--- a/src/printer/OITimeToolOutputBuilder.h
+++ b/src/printer/OITimeToolOutputBuilder.h
@@ -32,7 +32,7 @@ private:
     uint32_t killSignal_;
 
     // TODO
-    KillReason killReason_ = KillReason::OK;
+    KillReason killReason_ = KillReason::NONE;
     std::string killReasonComment_;
 };
 

--- a/src/printer/OutputBuilder.h
+++ b/src/printer/OutputBuilder.h
@@ -8,20 +8,8 @@ namespace printer {
 class OutputBuilder {
 public:
     enum KillReason {
-        OK, RE, RV, TLE, MLE, OLE
+        NONE, RE, RV, TLE, MLE, OLE
     };
-
-    static std::string killReasonName(KillReason reason) {
-        switch (reason) {
-            case OK: return "OK";
-            case RE: return "RE";
-            case RV: return "RV";
-            case TLE: return "TLE";
-            case MLE: return "MLE";
-            case OLE: return "OLE";
-        }
-        return "??";
-    }
 
     virtual ~OutputBuilder() = default;
 

--- a/src/printer/OutputBuilder.h
+++ b/src/printer/OutputBuilder.h
@@ -7,7 +7,7 @@ namespace printer {
 
 class OutputBuilder {
 public:
-    enum KillReason {
+    enum class KillReason {
         NONE, RE, RV, TLE, MLE, OLE
     };
 

--- a/src/printer/OutputBuilder.h
+++ b/src/printer/OutputBuilder.h
@@ -7,13 +7,29 @@ namespace printer {
 
 class OutputBuilder {
 public:
+    enum KillReason {
+        OK, RE, RV, TLE, MLE, OLE
+    };
+
+    static std::string killReasonName(KillReason reason) {
+        switch (reason) {
+            case OK: return "OK";
+            case RE: return "RE";
+            case RV: return "RV";
+            case TLE: return "TLE";
+            case MLE: return "MLE";
+            case OLE: return "OLE";
+        }
+        return "??";
+    }
+
     virtual ~OutputBuilder() = default;
 
     virtual OutputBuilder& setCyclesUsed(uint64_t cyclesUsed) { return *this; }
     virtual OutputBuilder& setMemoryPeak(uint64_t memoryPeakKb) { return *this; }
     virtual OutputBuilder& setExitStatus(uint32_t exitStatus) { return *this; }
     virtual OutputBuilder& setKillSignal(uint32_t killSignal) { return *this; }
-    virtual OutputBuilder& setKillReason(const std::string& reason) { return *this; }
+    virtual OutputBuilder& setKillReason(KillReason reason, const std::string& comment) { return *this; }
 
     virtual std::string dump() const { return ""; }
 };

--- a/src/seccomp/SeccompListener.cc
+++ b/src/seccomp/SeccompListener.cc
@@ -116,7 +116,7 @@ tracer::TraceAction SeccompListener::onTraceEvent(const tracer::TraceEvent& trac
 
     if (traceEventMsg == 0) {
         logger::debug("Default syscall filter action after syscall ", syscallName);
-        outputBuilder_->setKillReason("intercepted forbidden syscall " + syscallName);
+        outputBuilder_->setKillReason(printer::OutputBuilder::KillReason::RV, "intercepted forbidden syscall " + syscallName);
         return tracer::TraceAction::KILL;
     }
 

--- a/test/testsuits/test_policy.py
+++ b/test/testsuits/test_policy.py
@@ -14,4 +14,4 @@ class TestPolicy(unittest.TestCase):
     def test_1_sec_program(self):
         result = self.sio2jail.run(self.EVIL_PROGRAM_PATH)
         self.assertIn('forbidden syscall', result.message)
-        self.assertIn(result.return_code, [137])
+        self.assertIn(result.return_code, [121])


### PR DESCRIPTION
Fix compatibility with OITT output format, and kill reason tracking in general.

- Track machine-readable kill reason (RV/RE/TLE/etc) in OutputBuilder
- Don't confuse exit status with kill signal in OutputBuilder
- Fix compatibility with OITT output format by mangling the exit code reported in the first field of the result line the same way OITT mangles it