### PR TITLE
Fix various bugs

### DIFF
--- a/src/ns/MountNamespaceListener.cc
+++ b/src/ns/MountNamespaceListener.cc
@@ -90,12 +90,16 @@ void MountNamespaceListener::onPostExecute() {
 void MountNamespaceListener::BindMount::mount(const std::string& root) {
     TRACE(root);
 
-    uint32_t flags = 0;
+    uint32_t flags = MS_NODEV | MS_NOSUID;
     if (mode == Mode::RO) {
         flags |= MS_RDONLY;
     }
+    // NOTE: On bind mount, any flags other than MS_BIND and MS_REC are ignored by the kernel
     withErrnoCheck("bind mount " + sourcePath + " -> " + targetPath,
-                   ::mount, sourcePath.c_str(), (root + "/" + targetPath).c_str(), "", MS_BIND | MS_NODEV | MS_NOSUID | flags, nullptr);
+                   ::mount, sourcePath.c_str(), (root + "/" + targetPath).c_str(), "", MS_BIND, nullptr);
+    // remount to apply flags
+    withErrnoCheck("bind remount " + targetPath,
+                   ::mount, "none", (root + "/" + targetPath).c_str(), nullptr, MS_REMOUNT | MS_BIND | flags, nullptr);
 }
 
 void MountNamespaceListener::BindMount::umount(const std::string& root) {

--- a/src/ns/MountNamespaceListener.cc
+++ b/src/ns/MountNamespaceListener.cc
@@ -90,9 +90,12 @@ void MountNamespaceListener::onPostExecute() {
 void MountNamespaceListener::BindMount::mount(const std::string& root) {
     TRACE(root);
 
-    uint32_t flags = MS_NODEV | MS_NOSUID;
+    uint32_t flags = MS_NOSUID;
     if (mode == Mode::RO) {
         flags |= MS_RDONLY;
+    }
+    if (!dev) {
+        flags |= MS_NODEV;
     }
     // NOTE: On bind mount, any flags other than MS_BIND and MS_REC are ignored by the kernel
     withErrnoCheck("bind mount " + sourcePath + " -> " + targetPath,

--- a/src/ns/MountNamespaceListener.h
+++ b/src/ns/MountNamespaceListener.h
@@ -37,6 +37,7 @@ public:
 
         std::string sourcePath, targetPath;
         Mode mode;
+        bool dev = false;
     };
 
     struct Settings {

--- a/src/s2japp/ApplicationSettings.cc
+++ b/src/s2japp/ApplicationSettings.cc
@@ -233,14 +233,25 @@ void ApplicationSettings::addBindMount(const std::string& bindMountLine) {
 
     ns::MountNamespaceListener::BindMount bindMount{tokens[0], tokens[1], ns::MountNamespaceListener::BindMount::Mode::RO};
     if (tokens.size() == 3) {
-        if (tokens[2] == "ro") {
+        auto flags = split(tokens[2], ",");
+        if (flags.size() < 1) {
+            throw InvalidConfigurationException("Empty bind mount mode: " + tokens[2]);
+        }
+        if (flags[0] == "ro") {
             bindMount.mode = ns::MountNamespaceListener::BindMount::Mode::RO;
         }
-        else if (tokens[2] == "rw") {
+        else if (flags[0] == "rw") {
             bindMount.mode = ns::MountNamespaceListener::BindMount::Mode::RW;
         }
         else {
-            throw InvalidConfigurationException("No such bind mount mode: " + tokens[2]);
+            throw InvalidConfigurationException("No such bind mount mode: " + flags[0]);
+        }
+        if (flags.size() >= 2) {
+            if (flags[1] == "dev") {
+                bindMount.dev = true;
+            } else {
+                throw InvalidConfigurationException("No such bind mount flag: " + flags[1]);
+            }
         }
     }
 

--- a/src/seccomp/policy/DefaultPolicy.cc
+++ b/src/seccomp/policy/DefaultPolicy.cc
@@ -206,7 +206,7 @@ void DefaultPolicy::addFileSystemAccessRules(bool readOnly) {
         rules_.emplace_back(SeccompRule(
                     "open",
                     action::ActionAllow(),
-                    (filter::SyscallArg(1) & O_RDWR) == 0));
+                    (filter::SyscallArg(1) & (O_RDWR | O_WRONLY)) == 0));
 
         for (const auto& syscall: {
                 "unlink",

--- a/src/seccomp/policy/DefaultPolicy.cc
+++ b/src/seccomp/policy/DefaultPolicy.cc
@@ -193,8 +193,11 @@ void DefaultPolicy::addFileSystemAccessRules(bool readOnly) {
             "llistxattr",
             "flistxattr",
             "readlink",
+            "readlinkat",
             "access",
+            "faccessat",
             "getdents",
+            "getdents64",
             });
 
     rules_.emplace_back(SeccompRule(
@@ -208,12 +211,21 @@ void DefaultPolicy::addFileSystemAccessRules(bool readOnly) {
                     action::ActionAllow(),
                     (filter::SyscallArg(1) & (O_RDWR | O_WRONLY)) == 0));
 
+        rules_.emplace_back(SeccompRule(
+                    "openat",
+                    action::ActionAllow(),
+                    (filter::SyscallArg(2) & (O_RDWR | O_WRONLY)) == 0));
+
         for (const auto& syscall: {
                 "unlink",
                 "unlinkat",
                 "symlink",
+                "symlinkat",
                 "mkdir",
-                "fsetxattr"
+                "mkdirat",
+                "setxattr",
+                "lsetxattr",
+                "fsetxattr",
                 }) {
             rules_.emplace_back(SeccompRule(
                         syscall,
@@ -223,10 +235,16 @@ void DefaultPolicy::addFileSystemAccessRules(bool readOnly) {
     else {
         allowSyscalls({
                 "open",
+                "openat",
                 "unlink",
                 "unlinkat",
                 "symlink",
-                "mkdir"
+                "symlinkat",
+                "mkdir",
+                "mkdirat",
+                "setxattr",
+                "lsetxattr",
+                "fsetxattr",
                 });
     }
 }

--- a/src/tracer/TraceExecutor.cc
+++ b/src/tracer/TraceExecutor.cc
@@ -42,6 +42,8 @@ void TraceExecutor::onPostForkParent(pid_t childPid) {
 executor::ExecuteAction TraceExecutor::onExecuteEvent(const executor::ExecuteEvent& executeEvent) {
     TRACE();
 
+    static const uint64_t IGNORED_SIGNALS = (1 << SIGCHLD) | (1 << SIGCLD) | (1 << SIGURG) | (1 << SIGWINCH);
+
     TraceEvent event { executeEvent };
     Tracee tracee(traceePid_);
 
@@ -64,6 +66,7 @@ executor::ExecuteAction TraceExecutor::onExecuteEvent(const executor::ExecuteEve
             // Since our child is pid 1 we have to kill on delivery on uncaught
             // signal in favour of kernel.
             uint64_t caughtSignals = procfs::readProcFS(traceePid_, procfs::Field::SIG_CGT);
+            caughtSignals |= IGNORED_SIGNALS;
             if (!(caughtSignals & (1 << signal))) {
                 outputBuilder_->setKillSignal(signal);
                 logger::debug("Delivery of uncaught signal ", signal, " killing instead");


### PR DESCRIPTION
- fix mode checking in `open` syscall filter
- add missing filesystem syscalls to the defualt policy
- fix bind mount flags being passed in a way that makes the kernel totally ignore them
- add an option to bind-mount a device file
- don't kill supervised program after a signal that'd be ignored by default

Each of the above is a separate commit, feel free to review independently