### PR TITLE
Fix child process continuation

### DIFF
--- a/src/limits/ThreadsLimitListener.cc
+++ b/src/limits/ThreadsLimitListener.cc
@@ -48,8 +48,8 @@ std::tuple<tracer::TraceAction, tracer::TraceAction>
 ThreadsLimitListener::onPostClone(
         const tracer::TraceEvent& traceEvent,
         tracer::Tracee& tracee,
-        tracer::Tracee& traceeChild) {
-    TRACE(tracee.getPid(), traceeChild.getPid());
+        pid_t traceeChildPid) {
+    TRACE(tracee.getPid(), traceeChildPid);
     if (threadsLimit_ < 0) {
         outputBuilder_->setKillReason(
                 printer::OutputBuilder::KillReason::RV,
@@ -57,10 +57,10 @@ ThreadsLimitListener::onPostClone(
         return {tracer::TraceAction::KILL, tracer::TraceAction::KILL};
     }
 
-    threadsPids_.insert(traceeChild.getPid());
+    threadsPids_.insert(traceeChildPid);
     logger::debug(
             "Thread ",
-            traceeChild.getPid(),
+            traceeChildPid,
             " started, new thread count ",
             threadsPids_.size());
     if (threadsPids_.size() > static_cast<uint32_t>(threadsLimit_)) {

--- a/src/limits/ThreadsLimitListener.h
+++ b/src/limits/ThreadsLimitListener.h
@@ -21,7 +21,7 @@ public:
     std::tuple<tracer::TraceAction, tracer::TraceAction> onPostClone(
             const tracer::TraceEvent& traceEvent,
             tracer::Tracee& tracee,
-            tracer::Tracee& traceeChild) override;
+            pid_t traceeChildPid) override;
 
     executor::ExecuteAction onExecuteEvent(
             const executor::ExecuteEvent& executeEvent) override;

--- a/src/limits/ThreadsLimitListener.h
+++ b/src/limits/ThreadsLimitListener.h
@@ -18,10 +18,7 @@ class ThreadsLimitListener
 public:
     ThreadsLimitListener(int32_t threadsLimit);
 
-    std::tuple<tracer::TraceAction, tracer::TraceAction> onPostClone(
-            const tracer::TraceEvent& traceEvent,
-            tracer::Tracee& tracee,
-            pid_t traceeChildPid) override;
+    tracer::TraceAction onPostClone(pid_t traceePid, pid_t childPid) override;
 
     executor::ExecuteAction onExecuteEvent(
             const executor::ExecuteEvent& executeEvent) override;

--- a/src/logger/LoggerListener.cc
+++ b/src/logger/LoggerListener.cc
@@ -59,12 +59,12 @@ std::tuple<tracer::TraceAction, tracer::TraceAction>
 LoggerListener::onPostClone(
         const tracer::TraceEvent& /* traceEvent */,
         tracer::Tracee& tracee,
-        tracer::Tracee& traceeChild) {
+        pid_t traceeChildPid) {
     logger::debug(
             "Execution stage onPostClone, traceePid=",
             tracee.getPid(),
             ", traceeChildPid=",
-            traceeChild.getPid());
+            traceeChildPid);
     return {tracer::TraceAction::CONTINUE, tracer::TraceAction::CONTINUE};
 }
 

--- a/src/logger/LoggerListener.cc
+++ b/src/logger/LoggerListener.cc
@@ -55,17 +55,15 @@ tracer::TraceAction LoggerListener::onPostExec(
     return tracer::TraceAction::CONTINUE;
 }
 
-std::tuple<tracer::TraceAction, tracer::TraceAction>
-LoggerListener::onPostClone(
-        const tracer::TraceEvent& /* traceEvent */,
-        tracer::Tracee& tracee,
-        pid_t traceeChildPid) {
+tracer::TraceAction LoggerListener::onPostClone(
+        pid_t traceePid,
+        pid_t childPid) {
     logger::debug(
             "Execution stage onPostClone, traceePid=",
-            tracee.getPid(),
-            ", traceeChildPid=",
-            traceeChildPid);
-    return {tracer::TraceAction::CONTINUE, tracer::TraceAction::CONTINUE};
+            traceePid,
+            ", childPid=",
+            childPid);
+    return tracer::TraceAction::CONTINUE;
 }
 
 tracer::TraceAction LoggerListener::onTraceEvent(

--- a/src/logger/LoggerListener.h
+++ b/src/logger/LoggerListener.h
@@ -22,10 +22,7 @@ public:
     tracer::TraceAction onPostExec(
             const tracer::TraceEvent& traceEvent,
             tracer::Tracee& tracee) override;
-    std::tuple<tracer::TraceAction, tracer::TraceAction> onPostClone(
-            const tracer::TraceEvent& traceEvent,
-            tracer::Tracee& tracee,
-            pid_t traceeChildPid) override;
+    tracer::TraceAction onPostClone(pid_t traceePid, pid_t childPid) override;
     tracer::TraceAction onTraceEvent(
             const tracer::TraceEvent& traceEvent,
             tracer::Tracee& tracee) override;

--- a/src/logger/LoggerListener.h
+++ b/src/logger/LoggerListener.h
@@ -25,7 +25,7 @@ public:
     std::tuple<tracer::TraceAction, tracer::TraceAction> onPostClone(
             const tracer::TraceEvent& traceEvent,
             tracer::Tracee& tracee,
-            tracer::Tracee& traceeChild) override;
+            pid_t traceeChildPid) override;
     tracer::TraceAction onTraceEvent(
             const tracer::TraceEvent& traceEvent,
             tracer::Tracee& tracee) override;

--- a/src/tracer/TraceAction.h
+++ b/src/tracer/TraceAction.h
@@ -1,9 +1,25 @@
 #pragma once
 
+#include "common/Exception.h"
+#include "executor/ExecuteAction.h"
+
 namespace s2j {
 namespace tracer {
 
 enum class TraceAction { CONTINUE = 0, KILL = 1 };
 
+} // namespace tracer
+
+constexpr executor::ExecuteAction asExecuteAction(
+        const tracer::TraceAction traceAction) {
+    switch (traceAction) {
+    case tracer::TraceAction::CONTINUE:
+        return executor::ExecuteAction::CONTINUE;
+    case tracer::TraceAction::KILL:
+        return executor::ExecuteAction::KILL;
+    }
+
+    throw Exception("Unreachable code");
 }
+
 } // namespace s2j

--- a/src/tracer/TraceEventListener.h
+++ b/src/tracer/TraceEventListener.h
@@ -30,7 +30,7 @@ public:
     virtual std::tuple<TraceAction, TraceAction> onPostClone(
             const tracer::TraceEvent& traceEvent,
             tracer::Tracee& tracee,
-            tracer::Tracee& traceeChild) {
+            pid_t traceeChildPid) {
         return {TraceAction::CONTINUE, TraceAction::CONTINUE};
     }
 

--- a/src/tracer/TraceEventListener.h
+++ b/src/tracer/TraceEventListener.h
@@ -24,14 +24,11 @@ public:
     }
 
     /**
-     * Triggers in parent after each clone. Returns pair tracee action,
-     * tracee child action.
+     * Triggers in parent after each clone before paren and new child are
+     * resumed.
      */
-    virtual std::tuple<TraceAction, TraceAction> onPostClone(
-            const tracer::TraceEvent& traceEvent,
-            tracer::Tracee& tracee,
-            pid_t traceeChildPid) {
-        return {TraceAction::CONTINUE, TraceAction::CONTINUE};
+    virtual TraceAction onPostClone(pid_t traceePid, pid_t traceeChildPid) {
+        return TraceAction::CONTINUE;
     }
 
     /**

--- a/src/tracer/TraceExecutor.cc
+++ b/src/tracer/TraceExecutor.cc
@@ -128,12 +128,8 @@ executor::ExecuteAction TraceExecutor::onExecuteEvent(
         continueTracee(action, std::get<1>(handleSignalResult), event, tracee);
     }
 
-    if (action == TraceAction::KILL) {
-        return executor::ExecuteAction::KILL;
-    }
-
-    return executor::ExecuteAction::CONTINUE;
-} // namespace tracer
+    return asExecuteAction(action);
+}
 
 TraceAction TraceExecutor::onEventExec(
         const TraceEvent& event,
@@ -213,12 +209,7 @@ executor::ExecuteAction TraceExecutor::continueChildAfterClone(
             nullptr,
             injectedSignal);
 
-    if (childAction == TraceAction::CONTINUE) {
-        return executor::ExecuteAction::CONTINUE;
-    }
-    else {
-        return executor::ExecuteAction::KILL;
-    }
+    return asExecuteAction(childAction);
 }
 
 std::tuple<TraceAction, int> TraceExecutor::handleTraceeSignal(

--- a/src/tracer/TraceExecutor.h
+++ b/src/tracer/TraceExecutor.h
@@ -12,6 +12,8 @@
 
 #include <memory>
 #include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <unistd.h>
@@ -36,6 +38,10 @@ private:
 
     TraceAction onEventClone(const TraceEvent& executeEvent, Tracee& tracee);
 
+    executor::ExecuteAction continueChildAfterClone(
+            pid_t childPid,
+            TraceAction childAction);
+
     /* Returns action and injectedSignal */
     std::tuple<TraceAction, int> handleTraceeSignal(
             const TraceEvent& event,
@@ -50,6 +56,8 @@ private:
     static const uint64_t PTRACE_OPTIONS;
 
     std::shared_ptr<ProcessInfo> rootTraceeInfo_;
+    std::unordered_set<pid_t> stoppedPostCloneChildren_;
+    std::unordered_map<pid_t, TraceAction> delayedPostCloneChildrenAction_;
     bool hasExecved_{false};
 };
 

--- a/src/tracer/TraceExecutor.h
+++ b/src/tracer/TraceExecutor.h
@@ -38,9 +38,11 @@ private:
 
     TraceAction onEventClone(const TraceEvent& executeEvent, Tracee& tracee);
 
-    executor::ExecuteAction continueChildAfterClone(
-            pid_t childPid,
-            TraceAction childAction);
+    TraceAction onEventExit(const TraceEvent& executeEvent, Tracee& tracee);
+
+    TraceAction onRegularTrace(const TraceEvent& executeEvent, Tracee& tracee);
+
+    TraceAction onClone(pid_t parentPid, pid_t childPid);
 
     /* Returns action and injectedSignal */
     std::tuple<TraceAction, int> handleTraceeSignal(
@@ -50,14 +52,15 @@ private:
     void continueTracee(
             TraceAction action,
             int injectedSignal,
-            const TraceEvent& event,
-            Tracee& tracee);
+            pid_t traceePid);
 
     static const uint64_t PTRACE_OPTIONS;
 
     std::shared_ptr<ProcessInfo> rootTraceeInfo_;
+
+    std::unordered_map<pid_t, pid_t> stoppedPostCloneParentsByChild_;
     std::unordered_set<pid_t> stoppedPostCloneChildren_;
-    std::unordered_map<pid_t, TraceAction> delayedPostCloneChildrenAction_;
+
     bool hasExecved_{false};
 };
 


### PR DESCRIPTION
Sometimes parent process receives PTRACE_EVENT_CLONE before child
process is stopped by the kernel. Delay action execution in such
events processess until stop signal for child is delivered.