### PR TITLE
Fix caught signals check

### DIFF
--- a/src/tracer/TraceExecutor.cc
+++ b/src/tracer/TraceExecutor.cc
@@ -202,7 +202,7 @@ std::tuple<TraceAction, int> TraceExecutor::handleTraceeSignal(
         // Since our child is pid 1 we have to kill on delivery on uncaught
         // signal in favour of kernel.
         uint64_t caughtSignals =
-                procfs::readProcFS(tracee.getPid(), procfs::Field::SIG_CGT);
+                procfs::readProcFS(tracee.getPid(), procfs::Field::SIG_CGT) << 1;
         caughtSignals |= IGNORED_SIGNALS;
         if ((caughtSignals & (1 << signal)) == 0U) {
             outputBuilder_->setKillSignal(signal);

--- a/src/tracer/TraceExecutor.cc
+++ b/src/tracer/TraceExecutor.cc
@@ -201,6 +201,8 @@ std::tuple<TraceAction, int> TraceExecutor::handleTraceeSignal(
     else if (signal > 0) {
         // Since our child is pid 1 we have to kill on delivery on uncaught
         // signal in favour of kernel.
+        // Mask is shifted by one because the lowest bit of SigCgt mask
+        // corresponds to signal 1, not 0.
         uint64_t caughtSignals =
                 procfs::readProcFS(tracee.getPid(), procfs::Field::SIG_CGT) << 1;
         caughtSignals |= IGNORED_SIGNALS;


### PR DESCRIPTION
Hi.
The `caughtSignals` mask should be shifted by one, since the first bit corresponds to the signal with number 1.