### PR TITLE
Fix handling of rseq syscall

### DIFF
--- a/external/libseccomp.cmake
+++ b/external/libseccomp.cmake
@@ -59,8 +59,8 @@ IF((NOT DEFINED LIBSECCOMP_BUILD_OWN AND (NOT EXISTS "${libseccomp_LIB_PATH}" OR
     ENDIF()
 
     ExternalProject_Add(seccomp_project
-        URL https://github.com/seccomp/libseccomp/releases/download/v2.3.3/libseccomp-2.3.3.tar.gz
-        URL_HASH SHA256=7fc28f4294cc72e61c529bedf97e705c3acf9c479a8f1a3028d4cd2ca9f3b155
+        URL https://github.com/seccomp/libseccomp/releases/download/v2.5.4/libseccomp-2.5.4.tar.gz
+        URL_HASH SHA256=d82902400405cf0068574ef3dc1fe5f5926207543ba1ae6f8e7a1576351dcbdb
 
         CONFIGURE_COMMAND
             CFLAGS=${EXTRA_FLAGS} CXXFLAGS=${EXTRA_FLAGS} <SOURCE_DIR>/configure

--- a/src/common/ProcFS.cc
+++ b/src/common/ProcFS.cc
@@ -17,14 +17,17 @@ auto stoull = static_cast<
         std::stoull);
 const std::map<s2j::procfs::Field, FieldReader> FIELD_READERS = {
         {s2j::procfs::Field::VM_PEAK,
-         FieldReader{"VmPeak",
-                     std::bind(stoull, std::placeholders::_1, nullptr, 10)}},
+         FieldReader{
+                 "VmPeak",
+                 std::bind(stoull, std::placeholders::_1, nullptr, 10)}},
         {s2j::procfs::Field::VM_SIZE,
-         FieldReader{"VmSize",
-                     std::bind(stoull, std::placeholders::_1, nullptr, 10)}},
+         FieldReader{
+                 "VmSize",
+                 std::bind(stoull, std::placeholders::_1, nullptr, 10)}},
         {s2j::procfs::Field::SIG_CGT,
-         FieldReader{"SigCgt",
-                     std::bind(stoull, std::placeholders::_1, nullptr, 16)}}};
+         FieldReader{
+                 "SigCgt",
+                 std::bind(stoull, std::placeholders::_1, nullptr, 16)}}};
 
 } // namespace
 

--- a/src/limits/TimeLimitListener.cc
+++ b/src/limits/TimeLimitListener.cc
@@ -99,7 +99,8 @@ void TimeLimitListener::onPostExecute() {
     verifyTimeUsage(move(time));
 }
 
-executor::ExecuteAction TimeLimitListener::verifyTimeUsage(std::unique_ptr<TimeLimitListener::TimeUsage> timeUsage) {
+executor::ExecuteAction TimeLimitListener::verifyTimeUsage(
+        std::unique_ptr<TimeLimitListener::TimeUsage> timeUsage) {
     if (rTimelimitUs_ != 0 && timeUsage->realTimeUs > rTimelimitUs_) {
         outputBuilder_->setKillReason(
                 printer::OutputBuilder::KillReason::TLE,
@@ -141,7 +142,8 @@ uint64_t TimeLimitListener::getRealTimeUsage() const {
     return realTimeUsageUs;
 }
 
-TimeLimitListener::ProcessTimeUsage TimeLimitListener::getProcessTimeUsage() const {
+TimeLimitListener::ProcessTimeUsage TimeLimitListener::getProcessTimeUsage()
+        const {
     std::ifstream stat("/proc/" + std::to_string(childPid_) + "/stat");
     if (!stat.good()) {
         throw SystemException("Error reading /proc/childPid_/stat");
@@ -167,13 +169,11 @@ TimeLimitListener::ProcessTimeUsage TimeLimitListener::getProcessTimeUsage() con
     return result;
 }
 
-std::unique_ptr<TimeLimitListener::TimeUsage> TimeLimitListener::getTimeUsage() const {
-    return std::make_unique<TimeUsage>(
-        TimeUsage{
+std::unique_ptr<TimeLimitListener::TimeUsage> TimeLimitListener::getTimeUsage()
+        const {
+    return std::make_unique<TimeUsage>(TimeUsage{
             .realTimeUs = getRealTimeUsage(),
-            .processTimeUs = getProcessTimeUsage()
-        }
-    );
+            .processTimeUs = getProcessTimeUsage()});
 }
 
 } // namespace limits

--- a/src/printer/RealTimeOIOutputBuilder.cc
+++ b/src/printer/RealTimeOIOutputBuilder.cc
@@ -17,8 +17,7 @@ std::string RealTimeOIOutputBuilder::dump() const {
 
     std::stringstream ss;
     ss << killReasonName(reason) << " " << exitStatus_ << " "
-       << realMilliSecondsElapsed_ << " " 
-       << 0ULL << " " << memoryPeakKb_ << " "
+       << realMilliSecondsElapsed_ << " " << 0ULL << " " << memoryPeakKb_ << " "
        << syscallsCounter_ << std::endl;
     dumpStatus(ss);
     ss << std::endl;

--- a/src/s2japp/ApplicationSettings.cc
+++ b/src/s2japp/ApplicationSettings.cc
@@ -92,9 +92,8 @@ const FactoryMap<s2j::printer::OutputBuilder>
                   std::make_shared<s2j::printer::OITimeToolOutputBuilder>},
                  {"oiaug",
                   std::make_shared<s2j::printer::AugmentedOIOutputBuilder>},
-                  {"oireal",
-                  std::make_shared<s2j::printer::RealTimeOIOutputBuilder>}
-                  });
+                 {"oireal",
+                  std::make_shared<s2j::printer::RealTimeOIOutputBuilder>}});
 const std::string ApplicationSettings::DEFAULT_OUTPUT_FORMAT = "oitt";
 
 const FactoryMap<s2j::seccomp::policy::BaseSyscallPolicy>

--- a/src/seccomp/SeccompListener.cc
+++ b/src/seccomp/SeccompListener.cc
@@ -193,6 +193,10 @@ std::string SeccompListener::resolveSyscallNumber(
     char* name = seccomp_syscall_resolve_num_arch(
             SeccompContext::SECCOMP_FILTER_ARCHITECTURES.at(arch),
             syscallNumber);
+    if (name == NULL)
+        throw Exception(
+                "Can't resolve the name of syscall number " +
+                std::to_string(syscallNumber));
     std::string syscallName(name);
     free(name);
     return syscallName;

--- a/src/seccomp/policy/DefaultPolicy.cc
+++ b/src/seccomp/policy/DefaultPolicy.cc
@@ -86,6 +86,10 @@ void DefaultPolicy::addExecutionControlRules(bool allowFork) {
         rules_.emplace_back(SeccompRule(syscall, action::ActionTrace()));
     }
 
+    for (const auto& syscall: {"rseq"}) {
+        rules_.emplace_back(SeccompRule(syscall, action::ActionErrno(ENOSYS)));
+    }
+
     if (allowFork) {
         allowSyscalls({"fork"});
     }

--- a/src/seccomp/policy/DefaultPolicy.cc
+++ b/src/seccomp/policy/DefaultPolicy.cc
@@ -44,8 +44,7 @@ void DefaultPolicy::addExecutionControlRules(bool allowFork) {
              "clock_nanosleep",
              "open",
              "epoll_create1",
-             "openat"
-             });
+             "openat"});
 
     rules_.emplace_back(SeccompRule(
             "set_thread_area", action::ActionTrace([](auto& /* tracee */) {


### PR DESCRIPTION
Duplicate of the mistakenly closed #32, sorry for the commotion.

The currently used libseccomp (2.3.3 from 2018) was made for Linux 4.15 and doesn't know about the rseq (334) syscall, which seems to always be caught on my system (kernel 6.1, glibc 2.37, gcc 12.2.1) when using default options, like ``sio2jail -b dir:/ exe``. The issue doesn't occur when compiling with older gcc and glibc, like those from sio2's sandboxes, though for me it happens for every C++ program, even ``main(){}``.
If built with the old libseccomp, an exception is thrown, as we try to convert NULL to string when we can't resolve 334 to "rseq". When we use a modern version, it is properly reported that we use a forbidden syscall.

So this pull request:
- adds a proper, descriptive exception for when libseccomp can't resolve the name of a syscall
- updates libseccomp in libseccomp.cmake
- adds rseq to the list of syscalls allowed by the default seccomp policy
- formats code with ``make clang-format``.