### PR TITLE
Add new output formats

### DIFF
--- a/src/common/Exception.cc
+++ b/src/common/Exception.cc
@@ -2,6 +2,7 @@
 
 #include "logger/Logger.h"
 
+#include <cstdint>
 #include <cstring>
 
 namespace s2j {

--- a/src/common/Exception.h
+++ b/src/common/Exception.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace s2j {

--- a/src/common/ProcFS.cc
+++ b/src/common/ProcFS.cc
@@ -1,5 +1,6 @@
 #include "ProcFS.h"
 
+#include <cstdint>
 #include <fstream>
 #include <functional>
 #include <map>

--- a/src/limits/MemoryLimitListener.cc
+++ b/src/limits/MemoryLimitListener.cc
@@ -12,6 +12,7 @@
 #include <sys/time.h>
 
 #include <csignal>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 

--- a/src/limits/MemoryLimitListener.h
+++ b/src/limits/MemoryLimitListener.h
@@ -5,6 +5,8 @@
 #include "seccomp/policy/SyscallPolicy.h"
 #include "tracer/TraceEventListener.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace limits {
 

--- a/src/limits/OutputLimitListener.cc
+++ b/src/limits/OutputLimitListener.cc
@@ -8,6 +8,7 @@
 #include "seccomp/filter/LibSeccompFilter.h"
 
 #include <csignal>
+#include <cstdint>
 #include <sys/resource.h>
 #include <sys/time.h>
 

--- a/src/limits/OutputLimitListener.h
+++ b/src/limits/OutputLimitListener.h
@@ -4,6 +4,8 @@
 #include "printer/OutputSource.h"
 #include "seccomp/policy/SyscallPolicy.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace limits {
 

--- a/src/limits/ThreadsLimitListener.cc
+++ b/src/limits/ThreadsLimitListener.cc
@@ -7,6 +7,8 @@
 #include "seccomp/action/ActionKill.h"
 #include "seccomp/filter/LibSeccompFilter.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace limits {
 

--- a/src/limits/TimeLimitListener.cc
+++ b/src/limits/TimeLimitListener.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <chrono>
 #include <csignal>
+#include <cstdint>
 #include <ctime>
 #include <fstream>
 #include <limits>

--- a/src/limits/TimeLimitListener.cc
+++ b/src/limits/TimeLimitListener.cc
@@ -97,6 +97,8 @@ void TimeLimitListener::onPostExecute() {
     // TODO: run this just after child exit
     auto time = getTimeUsage();
     outputBuilder_->setRealTimeMicroseconds(time->realTimeUs);
+    outputBuilder_->setUserTimeMicroseconds(time->processTimeUs.uTimeUs);
+    outputBuilder_->setSysTimeMicroseconds(time->processTimeUs.sTimeUs);
     verifyTimeUsage(move(time));
 }
 

--- a/src/limits/TimeLimitListener.h
+++ b/src/limits/TimeLimitListener.h
@@ -4,6 +4,7 @@
 #include "printer/OutputSource.h"
 
 #include <chrono>
+#include <cstdint>
 
 namespace s2j {
 namespace limits {

--- a/src/ns/MountNamespaceListener.cc
+++ b/src/ns/MountNamespaceListener.cc
@@ -6,6 +6,7 @@
 #include "common/WithErrnoCheck.h"
 #include "logger/Logger.h"
 
+#include <cstdint>
 #include <fcntl.h>
 #include <linux/sched.h>
 #include <sys/mount.h>

--- a/src/ns/MountNamespaceListener.h
+++ b/src/ns/MountNamespaceListener.h
@@ -9,6 +9,7 @@
 
 #include <tclap/CmdLine.h>
 
+#include <cstdint>
 #include <string>
 
 namespace s2j {

--- a/src/perf/PerfListener.cc
+++ b/src/perf/PerfListener.cc
@@ -11,6 +11,7 @@
 #include <sys/mman.h>
 
 #include <csignal>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 

--- a/src/perf/PerfListener.h
+++ b/src/perf/PerfListener.h
@@ -4,6 +4,8 @@
 #include "executor/ExecuteEventListener.h"
 #include "printer/OutputSource.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace perf {
 

--- a/src/printer/AugmentedOIOutputBuilder.cc
+++ b/src/printer/AugmentedOIOutputBuilder.cc
@@ -24,20 +24,5 @@ std::string AugmentedOIOutputBuilder::dump() const {
     return ss.str();
 }
 
-void AugmentedOIOutputBuilder::dumpStatus(std::ostream& ss) const {
-    if (killReason_ != KillReason::NONE) {
-        ss << killReasonComment_;
-    }
-    else if (killSignal_ > 0) {
-        ss << "process exited due to signal " << killSignal_;
-    }
-    else if (exitStatus_ > 0) {
-        ss << "runtime error " << exitStatus_;
-    }
-    else {
-        ss << "ok";
-    }
-}
-
 } // namespace printer
 } // namespace s2j

--- a/src/printer/AugmentedOIOutputBuilder.h
+++ b/src/printer/AugmentedOIOutputBuilder.h
@@ -10,10 +10,6 @@ public:
     std::string dump() const override;
 
     const static std::string FORMAT_NAME;
-
-private:
-    void dumpStatus(std::ostream& ss) const;
-    int encodeStatusCode() const;
 };
 
 } // namespace printer

--- a/src/printer/HumanReadableOIOutputBuilder.cc
+++ b/src/printer/HumanReadableOIOutputBuilder.cc
@@ -1,0 +1,23 @@
+#include "HumanReadableOIOutputBuilder.h"
+
+#include <sstream>
+
+namespace s2j {
+namespace printer {
+
+const std::string HumanReadableOIOutputBuilder::FORMAT_NAME = "human";
+
+std::string HumanReadableOIOutputBuilder::dump() const {
+    // This is inspired by the oiejq script
+    std::stringstream ss;
+    ss << std::endl << "-------------------------" << std::endl << "Result: ";
+    dumpStatus(ss);
+    ss << std::endl
+       << "Time used: " << static_cast<float>(milliSecondsElapsed_) / 1000
+       << "s" << std::endl
+       << "Memory used: " << memoryPeakKb_ / 1024 << "MiB" << std::endl;
+    return ss.str();
+}
+
+} // namespace printer
+} // namespace s2j

--- a/src/printer/HumanReadableOIOutputBuilder.h
+++ b/src/printer/HumanReadableOIOutputBuilder.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "OIModelOutputBuilder.h"
+
+namespace s2j {
+namespace printer {
+
+class HumanReadableOIOutputBuilder : public OIModelOutputBuilder {
+public:
+    std::string dump() const override;
+
+    const static std::string FORMAT_NAME;
+};
+
+} // namespace printer
+} // namespace s2j

--- a/src/printer/OIModelOutputBuilder.cc
+++ b/src/printer/OIModelOutputBuilder.cc
@@ -1,5 +1,7 @@
 #include "OIModelOutputBuilder.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace printer {
 

--- a/src/printer/OIModelOutputBuilder.cc
+++ b/src/printer/OIModelOutputBuilder.cc
@@ -24,6 +24,16 @@ OutputBuilder& OIModelOutputBuilder::setRealTimeMicroseconds(uint64_t time) {
     return *this;
 }
 
+OutputBuilder& OIModelOutputBuilder::setUserTimeMicroseconds(uint64_t time) {
+    userMilliSecondsElapsed_ = time / 1000;
+    return *this;
+}
+
+OutputBuilder& OIModelOutputBuilder::setSysTimeMicroseconds(uint64_t time) {
+    sysMilliSecondsElapsed_ = time / 1000;
+    return *this;
+}
+
 OutputBuilder& OIModelOutputBuilder::setMemoryPeak(uint64_t memoryPeakKb) {
     memoryPeakKb_ = memoryPeakKb;
     return *this;

--- a/src/printer/OIModelOutputBuilder.cc
+++ b/src/printer/OIModelOutputBuilder.cc
@@ -1,6 +1,7 @@
 #include "OIModelOutputBuilder.h"
 
 #include <cstdint>
+#include <sstream>
 
 namespace s2j {
 namespace printer {
@@ -53,6 +54,21 @@ OutputBuilder& OIModelOutputBuilder::setKillReason(
     }
 
     return *this;
+}
+
+void OIModelOutputBuilder::dumpStatus(std::ostream& ss) const {
+    if (killReason_ != KillReason::NONE) {
+        ss << killReasonComment_;
+    }
+    else if (killSignal_ > 0) {
+        ss << "process exited due to signal " << killSignal_;
+    }
+    else if (exitStatus_ > 0) {
+        ss << "runtime error " << exitStatus_;
+    }
+    else {
+        ss << "ok";
+    }
 }
 
 } // namespace printer

--- a/src/printer/OIModelOutputBuilder.h
+++ b/src/printer/OIModelOutputBuilder.h
@@ -31,6 +31,8 @@ protected:
 
     KillReason killReason_ = KillReason::NONE;
     std::string killReasonComment_;
+
+    void dumpStatus(std::ostream& ss) const;
 };
 
 } // namespace printer

--- a/src/printer/OIModelOutputBuilder.h
+++ b/src/printer/OIModelOutputBuilder.h
@@ -13,6 +13,8 @@ public:
 
     OutputBuilder& setCyclesUsed(uint64_t cyclesUsed) override;
     OutputBuilder& setRealTimeMicroseconds(uint64_t time) override;
+    OutputBuilder& setUserTimeMicroseconds(uint64_t time) override;
+    OutputBuilder& setSysTimeMicroseconds(uint64_t time) override;
     OutputBuilder& setMemoryPeak(uint64_t memoryPeakKb) override;
     OutputBuilder& setExitStatus(uint32_t exitStatus) override;
     OutputBuilder& setKillSignal(uint32_t killSignal) override;
@@ -24,6 +26,8 @@ protected:
 
     uint64_t milliSecondsElapsed_;
     uint64_t realMilliSecondsElapsed_;
+    uint64_t userMilliSecondsElapsed_;
+    uint64_t sysMilliSecondsElapsed_;
     uint64_t memoryPeakKb_;
     uint64_t syscallsCounter_;
     uint32_t exitStatus_;

--- a/src/printer/OIModelOutputBuilder.h
+++ b/src/printer/OIModelOutputBuilder.h
@@ -2,6 +2,8 @@
 
 #include "OutputBuilder.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace printer {
 

--- a/src/printer/OITimeToolOutputBuilder.cc
+++ b/src/printer/OITimeToolOutputBuilder.cc
@@ -19,21 +19,6 @@ std::string OITimeToolOutputBuilder::dump() const {
     return ss.str();
 }
 
-void OITimeToolOutputBuilder::dumpStatus(std::ostream& ss) const {
-    if (killReason_ != KillReason::NONE) {
-        ss << killReasonComment_;
-    }
-    else if (killSignal_ > 0) {
-        ss << "process exited due to signal " << killSignal_;
-    }
-    else if (exitStatus_ > 0) {
-        ss << "runtime error " << exitStatus_;
-    }
-    else {
-        ss << "ok";
-    }
-}
-
 int OITimeToolOutputBuilder::encodeStatusCode() const {
     static const int CODE_SIG_BASE = 0;
     static const int CODE_RE_BASE = 200;

--- a/src/printer/OITimeToolOutputBuilder.h
+++ b/src/printer/OITimeToolOutputBuilder.h
@@ -12,7 +12,6 @@ public:
     const static std::string FORMAT_NAME;
 
 private:
-    void dumpStatus(std::ostream& ss) const;
     int encodeStatusCode() const;
 };
 

--- a/src/printer/OutputBuilder.h
+++ b/src/printer/OutputBuilder.h
@@ -36,6 +36,12 @@ public:
     virtual OutputBuilder& setRealTimeMicroseconds(uint64_t time) {
         return *this;
     }
+    virtual OutputBuilder& setUserTimeMicroseconds(uint64_t time) {
+        return *this;
+    }
+    virtual OutputBuilder& setSysTimeMicroseconds(uint64_t time) {
+        return *this;
+    }
     virtual OutputBuilder& setMemoryPeak(uint64_t memoryPeakKb) {
         return *this;
     }

--- a/src/printer/OutputBuilder.h
+++ b/src/printer/OutputBuilder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace s2j {

--- a/src/printer/RealTimeOIOutputBuilder.cc
+++ b/src/printer/RealTimeOIOutputBuilder.cc
@@ -24,20 +24,5 @@ std::string RealTimeOIOutputBuilder::dump() const {
     return ss.str();
 }
 
-void RealTimeOIOutputBuilder::dumpStatus(std::ostream& ss) const {
-    if (killReason_ != KillReason::NONE) {
-        ss << killReasonComment_;
-    }
-    else if (killSignal_ > 0) {
-        ss << "process exited due to signal " << killSignal_;
-    }
-    else if (exitStatus_ > 0) {
-        ss << "runtime error " << exitStatus_;
-    }
-    else {
-        ss << "ok";
-    }
-}
-
 } // namespace printer
 } // namespace s2j

--- a/src/printer/RealTimeOIOutputBuilder.h
+++ b/src/printer/RealTimeOIOutputBuilder.h
@@ -10,10 +10,6 @@ public:
     std::string dump() const override;
 
     const static std::string FORMAT_NAME;
-
-private:
-    void dumpStatus(std::ostream& ss) const;
-    int encodeStatusCode() const;
 };
 
 } // namespace printer

--- a/src/printer/UserTimeOIOutputBuilder.cc
+++ b/src/printer/UserTimeOIOutputBuilder.cc
@@ -1,0 +1,29 @@
+#include "UserTimeOIOutputBuilder.h"
+#include "common/Exception.h"
+
+#include <sstream>
+
+namespace s2j {
+namespace printer {
+
+const std::string UserTimeOIOutputBuilder::FORMAT_NAME = "oiuser";
+
+std::string UserTimeOIOutputBuilder::dump() const {
+    KillReason reason = killReason_;
+    if (reason == KillReason::NONE) {
+        if (killSignal_ > 0 || exitStatus_ > 0) {
+            reason = KillReason::RE;
+        }
+    }
+
+    std::stringstream ss;
+    ss << killReasonName(reason) << " " << exitStatus_ << " "
+       << userMilliSecondsElapsed_ << " " << 0ULL << " " << memoryPeakKb_ << " "
+       << syscallsCounter_ << std::endl;
+    dumpStatus(ss);
+    ss << std::endl;
+    return ss.str();
+}
+
+} // namespace printer
+} // namespace s2j

--- a/src/printer/UserTimeOIOutputBuilder.h
+++ b/src/printer/UserTimeOIOutputBuilder.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "OIModelOutputBuilder.h"
+
+namespace s2j {
+namespace printer {
+
+class UserTimeOIOutputBuilder : public OIModelOutputBuilder {
+public:
+    std::string dump() const override;
+
+    const static std::string FORMAT_NAME;
+};
+
+} // namespace printer
+} // namespace s2j

--- a/src/s2japp/Application.cc
+++ b/src/s2japp/Application.cc
@@ -21,6 +21,7 @@
 #include "seccomp/SeccompListener.h"
 #include "tracer/TraceExecutor.h"
 
+#include <cstdint>
 #include <iostream>
 #include <list>
 #include <utility>

--- a/src/s2japp/ApplicationArguments.cc
+++ b/src/s2japp/ApplicationArguments.cc
@@ -1,6 +1,7 @@
 #include "ApplicationArguments.h"
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <tclap/CmdLine.h>

--- a/src/s2japp/ApplicationArguments.h
+++ b/src/s2japp/ApplicationArguments.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 #include <tclap/CmdLine.h>

--- a/src/s2japp/ApplicationSettings.cc
+++ b/src/s2japp/ApplicationSettings.cc
@@ -9,6 +9,7 @@
 #include "seccomp/policy/DefaultPolicy.h"
 #include "seccomp/policy/PermissivePolicy.h"
 
+#include <cstdint>
 #include <seccomp.h>
 #include <sstream>
 

--- a/src/s2japp/ApplicationSettings.cc
+++ b/src/s2japp/ApplicationSettings.cc
@@ -4,8 +4,10 @@
 
 #include "common/Utils.h"
 #include "printer/AugmentedOIOutputBuilder.h"
+#include "printer/HumanReadableOIOutputBuilder.h"
 #include "printer/OITimeToolOutputBuilder.h"
 #include "printer/RealTimeOIOutputBuilder.h"
+#include "printer/UserTimeOIOutputBuilder.h"
 #include "seccomp/policy/DefaultPolicy.h"
 #include "seccomp/policy/PermissivePolicy.h"
 
@@ -91,8 +93,12 @@ const FactoryMap<s2j::printer::OutputBuilder>
         ApplicationSettings::OUTPUT_FORMATS(
                 {{"oitt",
                   std::make_shared<s2j::printer::OITimeToolOutputBuilder>},
+                 {"human",
+                  std::make_shared<s2j::printer::HumanReadableOIOutputBuilder>},
                  {"oiaug",
                   std::make_shared<s2j::printer::AugmentedOIOutputBuilder>},
+                 {"oiuser",
+                  std::make_shared<s2j::printer::UserTimeOIOutputBuilder>},
                  {"oireal",
                   std::make_shared<s2j::printer::RealTimeOIOutputBuilder>}});
 const std::string ApplicationSettings::DEFAULT_OUTPUT_FORMAT = "oitt";

--- a/src/s2japp/ApplicationSettings.h
+++ b/src/s2japp/ApplicationSettings.h
@@ -7,6 +7,7 @@
 
 #include "common/Utils.h"
 
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>

--- a/src/seccomp/SeccompContext.cc
+++ b/src/seccomp/SeccompContext.cc
@@ -4,6 +4,7 @@
 #include "common/FD.h"
 
 #include <algorithm>
+#include <cstdint>
 
 namespace s2j {
 namespace seccomp {

--- a/src/seccomp/SeccompContext.h
+++ b/src/seccomp/SeccompContext.h
@@ -6,6 +6,7 @@
 
 #include <seccomp.h>
 
+#include <cstdint>
 #include <list>
 #include <map>
 

--- a/src/seccomp/SeccompListener.cc
+++ b/src/seccomp/SeccompListener.cc
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <csignal>
+#include <cstdint>
 #include <utility>
 
 namespace s2j {

--- a/src/seccomp/SeccompListener.h
+++ b/src/seccomp/SeccompListener.h
@@ -14,6 +14,7 @@
 #include "tracer/TraceEventListener.h"
 #include "tracer/Tracee.h"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/src/seccomp/SeccompRule.cc
+++ b/src/seccomp/SeccompRule.cc
@@ -1,6 +1,8 @@
 #include "SeccompRule.h"
 #include "SeccompException.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace seccomp {
 

--- a/src/seccomp/SeccompRule.h
+++ b/src/seccomp/SeccompRule.h
@@ -4,6 +4,7 @@
 #include "filter/LibSeccompFilter.h"
 #include "filter/SyscallFilter.h"
 
+#include <cstdint>
 #include <memory>
 #include <type_traits>
 

--- a/src/seccomp/action/ActionAllow.cc
+++ b/src/seccomp/action/ActionAllow.cc
@@ -1,5 +1,7 @@
 #include "ActionAllow.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace seccomp {
 namespace action {

--- a/src/seccomp/action/ActionAllow.h
+++ b/src/seccomp/action/ActionAllow.h
@@ -2,6 +2,8 @@
 
 #include "SeccompAction.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace seccomp {
 namespace action {

--- a/src/seccomp/action/ActionErrno.cc
+++ b/src/seccomp/action/ActionErrno.cc
@@ -2,6 +2,8 @@
 
 #include "common/Exception.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace seccomp {
 namespace action {

--- a/src/seccomp/action/ActionErrno.h
+++ b/src/seccomp/action/ActionErrno.h
@@ -2,6 +2,8 @@
 
 #include "SeccompAction.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace seccomp {
 namespace action {

--- a/src/seccomp/action/ActionKill.cc
+++ b/src/seccomp/action/ActionKill.cc
@@ -1,5 +1,7 @@
 #include "ActionKill.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace seccomp {
 namespace action {

--- a/src/seccomp/action/ActionKill.h
+++ b/src/seccomp/action/ActionKill.h
@@ -2,6 +2,8 @@
 
 #include "SeccompAction.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace seccomp {
 namespace action {

--- a/src/seccomp/action/ActionTrace.cc
+++ b/src/seccomp/action/ActionTrace.cc
@@ -1,5 +1,6 @@
 #include "ActionTrace.h"
 
+#include <cstdint>
 #include <iostream>
 
 namespace s2j {

--- a/src/seccomp/action/ActionTrace.h
+++ b/src/seccomp/action/ActionTrace.h
@@ -2,6 +2,7 @@
 
 #include "SeccompAction.h"
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 

--- a/src/seccomp/action/SeccompAction.cc
+++ b/src/seccomp/action/SeccompAction.cc
@@ -1,5 +1,7 @@
 #include "SeccompAction.h"
 
+#include <cstdint>
+
 namespace s2j {
 namespace seccomp {
 namespace action {

--- a/src/seccomp/action/SeccompAction.h
+++ b/src/seccomp/action/SeccompAction.h
@@ -3,6 +3,7 @@
 #include "tracer/TraceAction.h"
 #include "tracer/Tracee.h"
 
+#include <cstdint>
 #include <seccomp.h>
 
 namespace s2j {

--- a/src/seccomp/filter/LibSeccompFilter.cc
+++ b/src/seccomp/filter/LibSeccompFilter.cc
@@ -1,6 +1,7 @@
 #include "LibSeccompFilter.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 
 namespace s2j {

--- a/src/seccomp/filter/LibSeccompFilter.h
+++ b/src/seccomp/filter/LibSeccompFilter.h
@@ -4,6 +4,7 @@
 
 #include <seccomp.h>
 
+#include <cstdint>
 #include <functional>
 
 namespace s2j {

--- a/src/tracer/TraceExecutor.cc
+++ b/src/tracer/TraceExecutor.cc
@@ -9,6 +9,7 @@
 #include <sys/wait.h>
 
 #include <csignal>
+#include <cstdint>
 
 namespace s2j {
 namespace tracer {

--- a/src/tracer/TraceExecutor.h
+++ b/src/tracer/TraceExecutor.h
@@ -10,6 +10,7 @@
 #include "executor/ExecuteEventListener.h"
 #include "printer/OutputSource.h"
 
+#include <cstdint>
 #include <memory>
 #include <tuple>
 #include <vector>

--- a/src/tracer/Tracee.cc
+++ b/src/tracer/Tracee.cc
@@ -7,6 +7,7 @@
 #include <sys/ptrace.h>
 
 #include <csignal>
+#include <cstdint>
 
 namespace s2j {
 namespace tracer {

--- a/src/tracer/Tracee.h
+++ b/src/tracer/Tracee.h
@@ -2,6 +2,7 @@
 
 #include "ProcessInfo.h"
 
+#include <cstdint>
 #include <string>
 
 #include <sys/user.h>


### PR DESCRIPTION
``oittuser``, as one can guess, is just ``oitt`` but with user CPU time instead of instrucion count.
The difference from ``oireal`` is quite small, but this should allow s2j to be used in place of sioworkers' ``DetailedUnprotectedExecutor``, allowing a significant security upgrade without having to modify problems' time limits at all.
The sys CPU time is also stored, as it might be useful in the future (maybe in sth like a ``human-full`` output format?).

``human`` provides an oiejq-inspired human-readable output.
Resolves https://github.com/sio2project/sio2jail/issues/8.

Sample outputs of the latter:
(here the first line is a program's stdout)
```
853564863

-------------------------
Result: ok
Time used: 0.151s
Memory used: 11MiB
```
```

-------------------------
Result: runtime error 5
Time used: 0.001s
Memory used: 0MiB
```
```

-------------------------
Result: process exited due to signal 11
Time used: 0s
Memory used: 0MiB
```
```

-------------------------
Result: time limit exceeded
Time used: 1.5s
Memory used: 0MiB
```