### PR TITLE
Reap leftover zombie processes

### DIFF
--- a/src/executor/Executor.cc
+++ b/src/executor/Executor.cc
@@ -190,6 +190,9 @@ void Executor::executeParent() {
     for (auto& listener: eventListeners_) {
         listener->onPostExecute();
     }
+    // This is needed, as most earlier waits have the WNOWAIT flag.
+    withErrnoCheck(
+            "final waitpid failed: ", {ECHILD}, waitpid, -1, nullptr, WNOHANG);
 }
 
 void Executor::setupSignalHandling() {


### PR DESCRIPTION
Resolves https://github.com/sio2project/sio2jail/issues/33.

We don't have to use the more complex ``waitid()``, as the child is sure to have exited already.