### PR TITLE
Added mremap tracing and fixed a bug in MemoryLimitListener

### DIFF
--- a/src/limits/MemoryLimitListener.cc
+++ b/src/limits/MemoryLimitListener.cc
@@ -88,7 +88,7 @@ tracer::TraceAction MemoryLimitListener::handleMemoryAllocation(
             ", ",
             VAR(memoryPeakKb_));
 
-    if (memoryUsage > memoryLimitKb_) {
+    if (memoryLimitKb_ > 0 && memoryUsage > memoryLimitKb_) {
         outputBuilder_->setKillReason(
                 printer::OutputBuilder::KillReason::MLE,
                 "memory limit exceeded");

--- a/src/limits/MemoryLimitListener.cc
+++ b/src/limits/MemoryLimitListener.cc
@@ -8,8 +8,15 @@
 #include "seccomp/action/ActionTrace.h"
 #include "seccomp/filter/LibSeccompFilter.h"
 
+#include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/time.h>
+
+#ifndef MREMAP_DONTUNMAP
+// Due to this flag being introduced in Linux 5.7 there are many system which do
+// not define it
+#define MREMAP_DONTUNMAP 4
+#endif
 
 #include <csignal>
 #include <cstdint>
@@ -40,33 +47,57 @@ MemoryLimitListener::MemoryLimitListener(uint64_t memoryLimitKb)
                     if (!vmPeakValid_) {
                         return tracer::TraceAction::CONTINUE;
                     }
-
-                    uint64_t memoryUsage = getMemoryUsageKb() +
-                                           tracee.getSyscallArgument(1) / 1024;
-                    memoryPeakKb_ = std::max(memoryPeakKb_, memoryUsage);
-                    outputBuilder_->setMemoryPeak(memoryPeakKb_);
-                    logger::debug(
-                            "Memory usage after mmap ",
-                            VAR(memoryUsage),
-                            ", ",
-                            VAR(memoryPeakKb_));
-
-                    if (memoryUsage > memoryLimitKb_) {
-                        outputBuilder_->setKillReason(
-                                printer::OutputBuilder::KillReason::MLE,
-                                "memory limit exceeded");
-                        logger::debug(
-                                "Limit ",
-                                VAR(memoryLimitKb_),
-                                " exceeded, killing tracee");
-                        return tracer::TraceAction::KILL;
-                    }
-                    return tracer::TraceAction::CONTINUE;
+                    return handleMemoryAllocation(
+                            tracee.getSyscallArgument(1) / 1024);
                 }),
                 Arg(0) == 0 && Arg(1) > MEMORY_LIMIT_MARGIN / 2));
     }
+    syscallRules_.emplace_back(seccomp::SeccompRule(
+            "mremap",
+            seccomp::action::ActionTrace([this](tracer::Tracee& tracee) {
+                TRACE();
+                uint64_t old_size = tracee.getSyscallArgument(1);
+                uint64_t new_size = tracee.getSyscallArgument(2);
+                uint64_t flags = tracee.getSyscallArgument(3);
+                if (!vmPeakValid_) {
+                    return tracer::TraceAction::CONTINUE;
+                }
+                bool doesntUnmap =
+                        (flags & MREMAP_DONTUNMAP) == MREMAP_DONTUNMAP;
+                // Allow user to shrink its memory
+                if (!doesntUnmap && old_size >= new_size) {
+                    return tracer::TraceAction::CONTINUE;
+                }
+                uint64_t newMemoryAllocated = new_size;
+                // Do not count already allocated memory
+                if (!doesntUnmap)
+                    newMemoryAllocated -= old_size;
+                newMemoryAllocated /= 1024;
+                return handleMemoryAllocation(newMemoryAllocated);
+            }),
+            Arg(2) > MEMORY_LIMIT_MARGIN / 2));
 }
+tracer::TraceAction MemoryLimitListener::handleMemoryAllocation(
+        uint64_t allocatedMemoryKb) {
+    uint64_t memoryUsage = getMemoryUsageKb() + allocatedMemoryKb;
+    memoryPeakKb_ = std::max(memoryPeakKb_, memoryUsage);
+    outputBuilder_->setMemoryPeak(memoryPeakKb_);
+    logger::debug(
+            "Memory usage after allocation ",
+            VAR(memoryUsage),
+            ", ",
+            VAR(memoryPeakKb_));
 
+    if (memoryUsage > memoryLimitKb_) {
+        outputBuilder_->setKillReason(
+                printer::OutputBuilder::KillReason::MLE,
+                "memory limit exceeded");
+        logger::debug(
+                "Limit ", VAR(memoryLimitKb_), " exceeded, killing tracee");
+        return tracer::TraceAction::KILL;
+    }
+    return tracer::TraceAction::CONTINUE;
+}
 void MemoryLimitListener::onPostForkChild() {
     TRACE();
 

--- a/src/limits/MemoryLimitListener.h
+++ b/src/limits/MemoryLimitListener.h
@@ -40,6 +40,7 @@ private:
     pid_t childPid_;
 
     std::vector<seccomp::SeccompRule> syscallRules_;
+    tracer::TraceAction handleMemoryAllocation(uint64_t allocatedMemoryKb);
 };
 
 } // namespace limits


### PR DESCRIPTION
Added mremap syscall tracing in the MemoryLimitListener to catch when the memory limit is exceeded and report a "memory limit exceeded" error instead of returning another possibly unrelated error (segfault, non-zero error code).

I also fixed a bug that caused the error ''memory limit exceeded'' to be displayed when there was no memory limit.
​
The error was caused by allocating more than ```MEMORY_LIMIT_MARGIN/2``` bytes of memory in a single mmap call, which resulted in post-allocation memory usage being compared to the memory limit(which was zero).
