### PR TITLE
Removed syscalls ```open``` and ```openat``` from policy defined in addExecutionControlRules

### DIFF
--- a/src/seccomp/policy/DefaultPolicy.cc
+++ b/src/seccomp/policy/DefaultPolicy.cc
@@ -42,9 +42,7 @@ void DefaultPolicy::addExecutionControlRules(bool allowFork) {
              "sigaltstack",
              "sigsuspend",
              "clock_nanosleep",
-             "open",
-             "epoll_create1",
-             "openat"});
+             "epoll_create1"});
 
     rules_.emplace_back(SeccompRule(
             "set_thread_area", action::ActionTrace([](auto& /* tracee */) {

--- a/src/seccomp/policy/DefaultPolicy.cc
+++ b/src/seccomp/policy/DefaultPolicy.cc
@@ -188,6 +188,16 @@ void DefaultPolicy::addFileSystemAccessRules(bool readOnly) {
                 "openat",
                 action::ActionAllow(),
                 (filter::SyscallArg(2) & (O_RDWR | O_WRONLY)) == 0));
+        for (const auto& mode: {O_RDWR, O_WRONLY}) {
+            rules_.emplace_back(SeccompRule(
+                    "open",
+                    action::ActionErrno(EROFS),
+                    (filter::SyscallArg(1) & mode) == mode));
+            rules_.emplace_back(SeccompRule(
+                    "openat",
+                    action::ActionErrno(EROFS),
+                    (filter::SyscallArg(2) & mode) == mode));
+        }
 
         for (const auto& syscall: {
                      "unlink",


### PR DESCRIPTION
Syscalls ```open``` and ```openat``` were handled two times.

Once without any restrictions in https://github.com/sio2project/sio2jail/blob/b5903c6d1fb04901b5ac025eaf97b84cedf27608/src/seccomp/policy/DefaultPolicy.cc#L45-L47

And the second time with a check to enforce read-only mode on the file system
https://github.com/sio2project/sio2jail/blob/b5903c6d1fb04901b5ac025eaf97b84cedf27608/src/seccomp/policy/DefaultPolicy.cc#L184-L192

The first policy was more permissive and made the second one useless(it always allowed syscall ```open``` without checking access mode) so I removed it.