### PR TITLE
Fix running tests

### DIFF
--- a/boxes/utils.sh
+++ b/boxes/utils.sh
@@ -15,7 +15,7 @@ clean_box() {
 }
 
 extract_deb() {
-    repo="http://ftp.debian.org/debian/pool/main"
+    repo="http://archive.debian.org/debian/pool/main"
     path="$1"
     dpkg=`basename "$path"`
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ ADD_TEST(
     NAME
         python
     COMMAND
-        bash -c "SIO2JAIL_BUILD_PATH='${CMAKE_BINARY_DIR}' '${CMAKE_SOURCE_DIR}/test/testsuits/main.py' -v"
+        bash -c "SIO2JAIL_BUILD_PATH='${CMAKE_BINARY_DIR}' python3 -m unittest discover -s '${CMAKE_SOURCE_DIR}/test/testsuits/' -v"
     WORKING_DIRECTORY
         "${CMAKE_SOURCE_DIR}"
     )

--- a/test/testsuits/main.py
+++ b/test/testsuits/main.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python3
-
-import nose
-
-nose.main()


### PR DESCRIPTION
Thix PR fixes building boxes and running tests. The tests may still not work depending on what compiler is present on host machine, we'll deal with this (move compiling to python with a fixed gcc version) in a separate PR.