### PR TITLE
Add syscalls used by JVM

### DIFF
--- a/src/seccomp/policy/DefaultPolicy.cc
+++ b/src/seccomp/policy/DefaultPolicy.cc
@@ -120,7 +120,7 @@ void DefaultPolicy::addSystemInformationRules() {
                    "getcwd",    "uname",         "olduname",     "oldolduname",
                    "sysinfo",   "clock_gettime", "clock_gettime64", "clock_getres",
                    "clock_getres_time64", "gettimeofday", "time",
-                   "sched_getaffinity", "sched_setaffinity", "sched_yield"});
+                   "sched_getaffinity", "sched_yield"});
 
     // Allow PR_SET_NAME (15) for thread naming - safe operation
     rules_.emplace_back(SeccompRule(


### PR DESCRIPTION
These syscalls were used by JVM when running Java/Kotlin programs. All seem safe to me